### PR TITLE
Experiment with decoupling loading overlay

### DIFF
--- a/demo/basic/popup/index.htm
+++ b/demo/basic/popup/index.htm
@@ -19,6 +19,93 @@
 
     <script>
 
+function renderOverlay({ isOpen, close }) {
+    let uid = 'abc10000',
+        tag = 'my-login-component',
+        context = 'def345',
+        focus = () => {};
+
+
+    function closeOverlay() {
+        const el = document.getElementById(uid);
+        el.parentNode.removeChild(el);
+    }
+
+    console.log('isOpen', isOpen);
+
+    if (isOpen === false) {
+        return closeOverlay();
+    }
+
+    function closeComponent(event) {
+        event.preventDefault();
+        event.stopPropagation();
+        closeOverlay();
+        return close();
+    }
+
+    function focusComponent(event) {
+        event.preventDefault();
+        event.stopPropagation();
+        return focus();
+    }
+
+
+
+    const results = pragmatic.node('div', { id: uid, 'onClick': focusComponent, 'class': `${ tag } ${ tag }-context-${ context } ${ tag }-focus` },
+
+        pragmatic.node('a', { 'href': '#', 'onClick': closeComponent, 'class': `${ tag }-close` }),
+
+        pragmatic.node('style', null, `
+            #${ uid } {
+                position: fixed;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+                background-color: rgba(0, 0, 0, 0.8);
+            }
+
+            #${ uid }.${ tag }-context-${ zoid.CONTEXT.POPUP } {
+                cursor: pointer;
+            }
+
+            #${ uid } .${ tag }-close {
+                position: absolute;
+                right: 16px;
+                top: 16px;
+                width: 16px;
+                height: 16px;
+                opacity: 0.6;
+            }
+
+            #${ uid } .${ tag }-close:hover {
+                opacity: 1;
+            }
+
+            #${ uid } .${ tag }-close:before,
+            #${ uid } .${ tag }-close:after {
+                position: absolute;
+                left: 8px;
+                content: ' ';
+                height: 16px;
+                width: 2px;
+                background-color: white;
+            }
+
+            #${ uid } .${ tag }-close:before {
+                transform: rotate(45deg);
+            }
+
+            #${ uid } .${ tag }-close:after {
+                transform: rotate(-45deg);
+            }
+        `)
+    ).render(pragmatic.dom({ dom: document }));
+
+    document.body.appendChild(results);
+    }
+
         // To render a popup we need to wait for a click event
 
         document.querySelector('#popupLogin').addEventListener('click', function() {
@@ -33,10 +120,17 @@
 
                 prefilledEmail: 'foo@bar.com',
 
+                // the overlay should close after this onLogin callback resolves
                 onLogin: function(email) {
-                    console.log('User logged in with email:', email);
-                    document.querySelector('#result').innerText = email + ' logged in!';
-                }
+                    return new Promise(resolve => {
+                        console.log('User logged in with email:', email);
+                        document.querySelector('#result').innerText = email + ' logged in!';
+
+                        setTimeout(() => resolve(), 10000);
+                    })
+                },
+
+                renderOverlay
             }).render('body', zoid.CONTEXT.POPUP);
         });
 

--- a/demo/basic/popup/index.htm
+++ b/demo/basic/popup/index.htm
@@ -18,94 +18,6 @@
     <div id="result"></div>
 
     <script>
-
-function renderOverlay({ isOpen, close }) {
-    let uid = 'abc10000',
-        tag = 'my-login-component',
-        context = 'def345',
-        focus = () => {};
-
-
-    function closeOverlay() {
-        const el = document.getElementById(uid);
-        el.parentNode.removeChild(el);
-    }
-
-    console.log('isOpen', isOpen);
-
-    if (isOpen === false) {
-        return closeOverlay();
-    }
-
-    function closeComponent(event) {
-        event.preventDefault();
-        event.stopPropagation();
-        closeOverlay();
-        return close();
-    }
-
-    function focusComponent(event) {
-        event.preventDefault();
-        event.stopPropagation();
-        return focus();
-    }
-
-
-
-    const results = pragmatic.node('div', { id: uid, 'onClick': focusComponent, 'class': `${ tag } ${ tag }-context-${ context } ${ tag }-focus` },
-
-        pragmatic.node('a', { 'href': '#', 'onClick': closeComponent, 'class': `${ tag }-close` }),
-
-        pragmatic.node('style', null, `
-            #${ uid } {
-                position: fixed;
-                top: 0;
-                left: 0;
-                width: 100%;
-                height: 100%;
-                background-color: rgba(0, 0, 0, 0.8);
-            }
-
-            #${ uid }.${ tag }-context-${ zoid.CONTEXT.POPUP } {
-                cursor: pointer;
-            }
-
-            #${ uid } .${ tag }-close {
-                position: absolute;
-                right: 16px;
-                top: 16px;
-                width: 16px;
-                height: 16px;
-                opacity: 0.6;
-            }
-
-            #${ uid } .${ tag }-close:hover {
-                opacity: 1;
-            }
-
-            #${ uid } .${ tag }-close:before,
-            #${ uid } .${ tag }-close:after {
-                position: absolute;
-                left: 8px;
-                content: ' ';
-                height: 16px;
-                width: 2px;
-                background-color: white;
-            }
-
-            #${ uid } .${ tag }-close:before {
-                transform: rotate(45deg);
-            }
-
-            #${ uid } .${ tag }-close:after {
-                transform: rotate(-45deg);
-            }
-        `)
-    ).render(pragmatic.dom({ dom: document }));
-
-    document.body.appendChild(results);
-    }
-
         // To render a popup we need to wait for a click event
 
         document.querySelector('#popupLogin').addEventListener('click', function() {
@@ -115,7 +27,6 @@ function renderOverlay({ isOpen, close }) {
             document.querySelector('#popupLogin').style.display = 'none';
 
             // Render the component
-
             MyLoginZoidComponent({
 
                 prefilledEmail: 'foo@bar.com',
@@ -128,9 +39,7 @@ function renderOverlay({ isOpen, close }) {
 
                         setTimeout(() => resolve(), 10000);
                     })
-                },
-
-                renderOverlay
+                }
             }).render('body', zoid.CONTEXT.POPUP);
         });
 

--- a/demo/basic/popup/login.htm
+++ b/demo/basic/popup/login.htm
@@ -25,13 +25,6 @@
     </svg>
 
     <script>
-
-        //
-        window.xprops.renderOverlay({
-            isOpen: true,
-            close: window.xprops.close
-        });
-
         // Hide the loading spinner by default
 
         document.querySelector('#spinner').style.display = 'none';
@@ -64,17 +57,8 @@
             setTimeout(function() {
 
                 // Since we had a successful login, call-back the parent page to let them know which user logged in:
-
-                window.xprops.onLogin(email)
-                    .then(() => {
-                        window.xprops.renderOverlay({
-                            isOpen: false,
-                            close: window.xprops.close
-                        });
-                    })
-
+                window.xprops.onLogin(email);
                 window.xprops.close();
-
 
             }, 2000);
         });

--- a/demo/basic/popup/login.htm
+++ b/demo/basic/popup/login.htm
@@ -26,6 +26,12 @@
 
     <script>
 
+        //
+        window.xprops.renderOverlay({
+            isOpen: true,
+            close: window.xprops.close
+        });
+
         // Hide the loading spinner by default
 
         document.querySelector('#spinner').style.display = 'none';
@@ -59,8 +65,16 @@
 
                 // Since we had a successful login, call-back the parent page to let them know which user logged in:
 
-                window.xprops.onLogin(email);
+                window.xprops.onLogin(email)
+                    .then(() => {
+                        window.xprops.renderOverlay({
+                            isOpen: false,
+                            close: window.xprops.close
+                        });
+                    })
+
                 window.xprops.close();
+
 
             }, 2000);
         });

--- a/demo/basic/popup/login.js
+++ b/demo/basic/popup/login.js
@@ -1,3 +1,4 @@
+const doc = window.document;
 
 window.MyLoginZoidComponent = zoid.create({
 
@@ -7,78 +8,10 @@ window.MyLoginZoidComponent = zoid.create({
 
     // The url that will be loaded in the iframe or popup, when someone includes my component on their page
 
-    url: './login.htm',
-    
+    url: 'http://localhost:1337/demo/basic/popup/login.htm',
+
     dimensions: {
         width:  '300px',
         height: '150px'
-    },
-
-    // The background overlay
-
-    containerTemplate: ({ uid, tag, context, focus, close, doc }) => {
-
-        function closeComponent(event) {
-            event.preventDefault();
-            event.stopPropagation();
-            return close();
-        }
-
-        function focusComponent(event) {
-            event.preventDefault();
-            event.stopPropagation();
-            return focus();
-        }
-
-        return pragmatic.node('div', { id: uid, 'onClick': focusComponent, 'class': `${ tag } ${ tag }-context-${ context } ${ tag }-focus` },
-
-            pragmatic.node('a', { 'href': '#', 'onClick': closeComponent, 'class': `${ tag }-close` }),
-
-            pragmatic.node('style', null, `
-                #${ uid } {
-                    position: fixed;
-                    top: 0;
-                    left: 0;
-                    width: 100%;
-                    height: 100%;
-                    background-color: rgba(0, 0, 0, 0.8);
-                }
-
-                #${ uid }.${ tag }-context-${ zoid.CONTEXT.POPUP } {
-                    cursor: pointer;
-                }
-
-                #${ uid } .${ tag }-close {
-                    position: absolute;
-                    right: 16px;
-                    top: 16px;
-                    width: 16px;
-                    height: 16px;
-                    opacity: 0.6;
-                }
-
-                #${ uid } .${ tag }-close:hover {
-                    opacity: 1;
-                }
-
-                #${ uid } .${ tag }-close:before,
-                #${ uid } .${ tag }-close:after {
-                    position: absolute;
-                    left: 8px;
-                    content: ' ';
-                    height: 16px;
-                    width: 2px;
-                    background-color: white;
-                }
-
-                #${ uid } .${ tag }-close:before {
-                    transform: rotate(45deg);
-                }
-
-                #${ uid } .${ tag }-close:after {
-                    transform: rotate(-45deg);
-                }
-            `)
-        ).render(pragmatic.dom({ doc }));
     }
 });

--- a/demo/basic/popup/login.js
+++ b/demo/basic/popup/login.js
@@ -1,4 +1,10 @@
-const doc = window.document;
+let overlayElement;
+
+function closeOverlay() {
+    if (overlayElement) {
+        overlayElement.parentNode.removeChild(overlayElement);
+    }
+}
 
 window.MyLoginZoidComponent = zoid.create({
 
@@ -13,5 +19,92 @@ window.MyLoginZoidComponent = zoid.create({
     dimensions: {
         width:  '300px',
         height: '150px'
+    },
+
+    // idea - container template is responsible for intializing and first showing the loadingOverlay
+    //      - however, it does not own the DOM for it. So closing the popup does not close the overlay
+    containerTemplate: ({ uid, tag, context, focus, close, doc }) => {
+
+        function closeComponent(event) {
+            event.preventDefault();
+            event.stopPropagation();
+            closeOverlay();
+
+            return close();
+        }
+
+        function focusComponent(event) {
+            event.preventDefault();
+            event.stopPropagation();
+            return focus();
+        }
+
+        overlayElement = pragmatic.node('div', { id: uid, 'onClick': focusComponent, 'class': `${ tag } ${ tag }-context-${ context } ${ tag }-focus` },
+
+            pragmatic.node('a', { 'href': '#', 'onClick': closeComponent, 'class': `${ tag }-close` }),
+
+            pragmatic.node('style', null, `
+                #${ uid } {
+                    position: fixed;
+                    top: 0;
+                    left: 0;
+                    width: 100%;
+                    height: 100%;
+                    background-color: rgba(0, 0, 0, 0.8);
+                }
+
+                #${ uid }.${ tag }-context-${ zoid.CONTEXT.POPUP } {
+                    cursor: pointer;
+                }
+
+                #${ uid } .${ tag }-close {
+                    position: absolute;
+                    right: 16px;
+                    top: 16px;
+                    width: 16px;
+                    height: 16px;
+                    opacity: 0.6;
+                }
+
+                #${ uid } .${ tag }-close:hover {
+                    opacity: 1;
+                }
+
+                #${ uid } .${ tag }-close:before,
+                #${ uid } .${ tag }-close:after {
+                    position: absolute;
+                    left: 8px;
+                    content: ' ';
+                    height: 16px;
+                    width: 2px;
+                    background-color: white;
+                }
+
+                #${ uid } .${ tag }-close:before {
+                    transform: rotate(45deg);
+                }
+
+                #${ uid } .${ tag }-close:after {
+                    transform: rotate(-45deg);
+                }
+            `)
+        ).render(pragmatic.dom({ doc }));
+
+        document.body.appendChild(overlayElement);
+    },
+
+    props: {
+        onLogin: {
+            type: 'function',
+
+            decorate(original) {
+                return function() {
+                    return original.value.apply(this, arguments)
+                        .finally(() => {
+                            closeOverlay();
+                        })
+                };
+            }
+        }
     }
 });


### PR DESCRIPTION
This PR experiments with decoupling closing the popup from closing the overlay. 

Open Questions

**1. What should the zoid `containerTemplate` be responsible for? Should it still initialize the overlay?**

I updated it's functionality to render the actual overlay outside of the zoid components DOM. That way the overlay doesn't close whenever the popup closes while still taking advantage of how fast `containerTemplate` executes and the params we get from it (uid, dom, etc).

**2. How do we simulate the `onApprove` use case with this example?** 

I'm currently using the props decorator with the `onLogin`  prop to chain to the promise and close the overlay when it's resolved. Seems to work for closing the overlay after the popup is already closed 😄 

**3. How to close the overlay when the user purposely closes the popup to cancel the transaction?**

TODO: figure this one out.